### PR TITLE
Edited the 'json_success' key according to the responses of requests sent to APIs.

### DIFF
--- a/MapSyncer/components/login_controller.py
+++ b/MapSyncer/components/login_controller.py
@@ -89,7 +89,7 @@ class LoginController:
         if isinstance(error, urllib.error.HTTPError):
             LOGGER.warning("Can't get osm id")
             LOGGER.warning("Please report this issue with the error code on "
-                           "https://github.com/openstreetcam/upload-scripts")
+                           "https://github.com/mapilio/MapSyncer")
             LOGGER.warning(error.code)
             LOGGER.warning(error.read())
             sys.exit()
@@ -102,7 +102,7 @@ class LoginController:
         else:
             LOGGER.warning("Error message: %s", str(error))
             LOGGER.warning("Please report this issue with the error message"
-                           "https://github.com/openstreetcam/upload-scripts")
+                           "https://github.com/mapilio/MapSyncer")
             sys.exit()
 
     @classmethod
@@ -117,7 +117,7 @@ class LoginController:
         LOGGER.warning("Can't get osc authorization right now please try again "
                        "or if you already did this.")
         LOGGER.warning("Please report this issue with the error message on "
-                       "https://github.com/openstreetcam/upload-scripts")
+                       "https://github.com/mapilio/MapSyncer")
         LOGGER.warning(exception)
         sys.exit()
 

--- a/MapSyncer/run.py
+++ b/MapSyncer/run.py
@@ -123,10 +123,14 @@ def folder_selection(path):
         print(f"{Fore.LIGHTYELLOW_EX}Uploading all folders...")
         json_file_path = ".download_logs.json"
         folders_to_upload = []
+
         with open(json_file_path, 'r') as f:
             data = json.load(f)
             for folder in data:
-                if folder.get('upload_success') == False:
+                if not folder.get('json_success'):
+                    print(f"{Fore.RED}The json file of the file with sequence id: {folder['seq_id']} was not found, please download the folder again.")
+                    continue
+                elif not folder.get('upload_success'):
                     folders_to_upload.append(folder.get('seq_id'))
 
         for folder_name in os.listdir(path):
@@ -138,10 +142,13 @@ def folder_selection(path):
 
             if folder_name_numeric in folders_to_upload:
                 upload_command = f"mapilio_kit upload --processed {folder_path}"
-                os.system(upload_command)
+                result = os.system(upload_command)
+
+                if result != 0:
+                    print(f"{Fore.RED}Error occurred while uploading {folder_path}")
+                    continue
 
                 update_folder_status(folder_name_numeric, json_file_path)
-
         print(f"{Fore.LIGHTGREEN_EX}All folders uploaded. 🎉")
 
     elif choice == '2':
@@ -157,12 +164,20 @@ def folder_selection(path):
         with open(json_file_path, 'r') as f:
             data = json.load(f)
             for folder in data:
-                 if folder.get('upload_success') == True:
-                     print(f"{Fore.LIGHTGREEN_EX}Folder '{folder_name_numeric}' already uploaded 🎉.{Fore.RESET}")
-                     folder_selection(path)
+                if folder.get('seq_id') == folder_name_numeric:
+                    if folder.get('upload_success') == True:
+                        print(f"{Fore.LIGHTGREEN_EX}Folder '{folder_name_numeric}' already uploaded 🎉.{Fore.RESET}")
+                        folder_selection(path)
+                    elif folder.get('json_success') == False:
+                        print(f"{Fore.RED}The json file of the file with sequence id: {folder['seq_id']} was not found, please download the folder again.")
+                        folder_selection(path)
+        result = os.system(upload_command)
 
-        os.system(upload_command)
-        update_folder_status(folder_name_numeric, json_file_path)
+        if result != 0:
+            print(f"{Fore.RED}Error occurred while uploading {folder_name_numeric}")
+        else:
+            update_folder_status(folder_name_numeric, json_file_path)
+
         folder_selection(path)
 
     else:

--- a/MapSyncer/run.py
+++ b/MapSyncer/run.py
@@ -166,7 +166,7 @@ def folder_selection(path):
             for folder in data:
                 if folder.get('seq_id') == folder_name_numeric:
                     if folder.get('upload_success') == True:
-                        print(f"{Fore.LIGHTGREEN_EX}Folder '{folder_name_numeric}' already uploaded 🎉.{Fore.RESET}")
+                        print(f"{Fore.LIGHTGREEN_EX}Folder '{folder_name_numeric}' was already uploaded 🎉.{Fore.RESET}")
                         folder_selection(path)
                     elif folder.get('json_success') == False:
                         print(f"{Fore.RED}The json file of the file with sequence id: {folder['seq_id']} was not found, please download the folder again.")


### PR DESCRIPTION
- The access_token key will not be sent as a parameter when sending a request to the details API.

- If the responses from the APIs to which the request is sent fail, the "json_success" key will be set to "False" in the log file for that sequence.

- During the upload phase, if the "json_success" key of the sequence to be uploaded is "False", an informational message will be printed.

- If any errors are received in the Mapilio Kit console during the upload phase, an informational message will be printed.