### PR TITLE
Mapilio login system moved to flask app.

### DIFF
--- a/MapSyncer/app.py
+++ b/MapSyncer/app.py
@@ -299,4 +299,4 @@ def get_user_name():
 
 
 if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=5050, threaded=True, debug=True)
+    app.run(host='0.0.0.0', port=5050, threaded=True)

--- a/MapSyncer/app.py
+++ b/MapSyncer/app.py
@@ -1,28 +1,40 @@
+import argparse
 import json
 import os
 import shutil
-import argparse
 
-from flask import Flask, render_template, request, jsonify
+from flask import Flask, render_template, request, jsonify, redirect, url_for
+from mapilio_kit.base import authenticator
+from mapilio_kit.components.edit_config import edit_config
+from mapilio_kit.components.login import list_all_users
 
 from MapSyncer.components.download import download_user_images, check_sequence_status, progress
-from MapSyncer.components.osc_api_gateway import OSCApi
 from MapSyncer.components.osc_api_gateway import OSCAPISubDomain
-
+from MapSyncer.components.osc_api_gateway import OSCApi
 
 app = Flask(__name__)
+app.secret_key = "1213"
 parser = argparse.ArgumentParser()
 parser.add_argument('--username', type=str, help='Username')
 parser.add_argument('--to_path', type=str, help='Path to download images')
 args = parser.parse_args()
+user_name = args.username
 
-current_directory = os.path.dirname(os.path.abspath(__file__))
-download_logs_json_path = os.path.join(current_directory, ".download_logs.json")
+MERGED_RESPONSE = os.path.join(os.path.expanduser("~"), ".config", "mapilio", "configs", "MapSyncer",
+                               f"{user_name}_sequences_logs.json")
+
+DOWNLOAD_LOGS = os.path.join(os.path.expanduser("~"), ".config", "mapilio", "configs", "MapSyncer",
+                             "download_logs.json")
+
+
+def get_args_mapilio(func):
+    arg_names = func.__code__.co_varnames[:func.__code__.co_argcount]
+    return {arg: None for arg in arg_names}
 
 
 def save_data(data):
     try:
-        with open(download_logs_json_path, 'w', encoding='utf-8') as f:
+        with open(DOWNLOAD_LOGS, 'w', encoding='utf-8') as f:
             json.dump(data, f, indent=4)
     except Exception as e:
         print(e)
@@ -31,17 +43,15 @@ def save_data(data):
 
 def load_data():
     try:
-        with open(download_logs_json_path, encoding='utf-8') as f:
+        with open(DOWNLOAD_LOGS, encoding='utf-8') as f:
             return json.load(f)
     except Exception as e:
         print(e)
         return None
 
+
 def get_sequences():
-    user_name = args.username
-    current_directory = os.path.dirname(os.path.abspath(__file__))
-    sequence_json_path = os.path.join(current_directory, f".{user_name}_merged_response.json")
-    with open(sequence_json_path, encoding='utf-8') as f:
+    with open(MERGED_RESPONSE, encoding='utf-8') as f:
         response_data = json.load(f)
 
     sequence_list = []
@@ -51,54 +61,92 @@ def get_sequences():
             sequence_list.append(eleman['id'])
     return sequence_list
 
+
 @app.route('/check-status/<sequence_id>', methods=['GET'])
 def check_status(sequence_id):
     status = check_sequence_status(sequence_id)
     return jsonify({"status": status})
 
 
+@app.route('/mapilio-login', methods=['POST'])
+def mapilio_login():
+    args = get_args_mapilio(edit_config)
+    username = request.form['username'].strip()
+    email = request.form['email'].strip()
+    password = request.form['password'].strip()
+
+    args["user_name"] = username
+    args["user_email"] = email
+    args["user_password"] = password
+    args["gui"] = True
+    check_authenticate = authenticator().perform_task(args)
+
+    if check_authenticate['status']:
+        return redirect(url_for('display_sequence'))
+    else:
+        message = check_authenticate['message']
+        return render_template('mapilio-login.html', message=message)
+
+import math
 @app.route('/', methods=['GET'])
 def display_sequence():
     """Displays the sequence data"""
-    user_name = args.username
-    current_directory = os.path.dirname(os.path.abspath(__file__))
-    sequence_json_path = os.path.join(current_directory, f".{user_name}_merged_response.json")
+    check_authenticate = False
 
-    try:
-        with open(sequence_json_path, encoding='utf-8') as f:
-            response_data = json.load(f)
-    except Exception as e:
-        print(e)
-        response_data = None
+    if len(list_all_users()) == 0:
+        return render_template('mapilio-login.html')
+    elif len(list_all_users()) >= 2:
+        username = input("Found multiple Mapilio accounts. Please specify your username.\n")
+    else:
+        check_authenticate = True
 
-    if response_data is None:
-        message = "No data available. Please check the terminal for further details."
-        return render_template('display-sequence.html', message=message)
+    if check_authenticate:
+        try:
+            with open(MERGED_RESPONSE, encoding='utf-8') as f:
+                response_data = json.load(f)
+        except Exception as e:
+            print(e)
+            response_data = None
 
-    download_logs = load_data() or []
+        if response_data is None:
+            message = "No data available. Press the button below to fetch the sequences."
+            return render_template('display-sequence.html', message=message)
 
-    currentPageItems_index = 0
-    sequence_data = []
-    while str(currentPageItems_index) in response_data:
-        sequence_data.extend(response_data[str(currentPageItems_index)]['currentPageItems'])
-        currentPageItems_index += 1
+        download_logs = load_data() or []
+        sequence_data = []
 
-    for item in sequence_data:
-        seq_id = item.get('id')
-        log_item = next((log for log in download_logs if log.get('seq_id') == seq_id), None)
+        for page_data in response_data.values():
+            sequence_data.extend(page_data.get('currentPageItems', []))
 
-        if log_item:
-            item['upload_disabled'] = log_item.get('upload_success', False)
-            item['download_disabled'] = log_item.get('download_success', False)
-        else:
-            item['upload_disabled'] = False
-            item['download_disabled'] = False
+        total_sequences = len(sequence_data)
+        items_per_page = 39
+        current_page = request.args.get('page', 1, type=int)
+        start_index = (current_page - 1) * items_per_page
+        end_index = min(start_index + items_per_page, total_sequences)
 
-    return render_template('display-sequence.html', sequence_data=sequence_data)
+        sequence_data = sequence_data[start_index:end_index]
+
+        for item in sequence_data:
+            seq_id = item.get('id')
+            log_item = next((log for log in download_logs if log.get('seq_id') == seq_id), None)
+
+            if log_item:
+                item['upload_disabled'] = log_item.get('upload_success', False)
+                item['download_disabled'] = log_item.get('download_success', False)
+            else:
+                item['upload_disabled'] = False
+                item['download_disabled'] = False
+
+        num_pages = math.ceil(total_sequences / items_per_page)
+        return render_template('display-sequence.html', sequence_data=sequence_data, current_page=current_page,
+                           num_pages=num_pages, items_per_page=items_per_page)
 
 
 @app.route('/details', methods=['GET', 'POST'])
 def details_page():
+    if len(list_all_users()) == 0:
+        return render_template('mapilio-login.html')
+
     download_logs = load_data()
 
     if download_logs is None:
@@ -107,6 +155,7 @@ def details_page():
 
     sequence_filter = 'all'
 
+    # POST
     if request.method == 'POST':
         sequence_filter = request.form['filter']
 
@@ -125,34 +174,37 @@ def details_page():
 
 @app.route('/sequence-edit', methods=['GET', 'POST'])
 def update_json():
+    if len(list_all_users()) == 0:
+        return render_template('mapilio-login.html')
     if request.method == 'GET':
         return render_template('sequence-edit.html')
 
     # POST
-    seq_id = request.form.get('seq_id').strip()
-    key = request.form.get('key')
-    new_value = request.form.get('new_value')
+    if request.method == 'POST':
+        seq_id = request.form.get('seq_id').strip()
+        key = request.form.get('key')
+        new_value = request.form.get('new_value')
 
-    if not seq_id or not key or new_value not in ['true', 'false']:
-        return jsonify({"success": False, "message": "Invalid request data"}), 400
+        if not seq_id or not key or new_value not in ['true', 'false']:
+            return jsonify({"success": False, "message": "Invalid request data"}), 400
 
-    data = load_data()
-    if data is None:
-        return jsonify({"success": False, "message": "Log file not found"}), 404
+        data = load_data()
+        if data is None:
+            return jsonify({"success": False, "message": "Log file not found"}), 404
 
-    for item in data:
-        if item['seq_id'] == seq_id:
-            item[key] = new_value == 'true'
-            save_data(data)
-            return jsonify({"success": True, "message": "JSON updated successfully"})
+        for item in data:
+            if item['seq_id'] == seq_id:
+                item[key] = new_value == 'true'
+                save_data(data)
+                return jsonify({"success": True, "message": "JSON updated successfully"})
     return jsonify({"message": "Sequence ID not found"}), 404
 
 
 @app.route('/download-sequence', methods=['POST'])
-def download_sequence(to_path=None, sequence_id=None):
-    if to_path is None:
-        to_path = args.to_path
-
+def download_sequence(sequence_id=None):
+    to_path = args.to_path
+    if not to_path:
+        return jsonify({"status": "error", "message": "missing 'to_path' parameter"}), 400
     response, _ = download_progress_bar()
 
     if sequence_id is None:
@@ -193,6 +245,7 @@ def upload_sequence():
                     return jsonify({"status": "success", "message": "Sequence uploaded successfully"})
     return jsonify({"status": "error", "message": "Sequence not found in log file or sequence folder not found."}), 404
 
+
 @app.route('/download-progress-bar', methods=['POST'])
 def download_progress_bar():
     sequence_id = request.form.get('sequence_id')
@@ -202,8 +255,48 @@ def download_progress_bar():
         return jsonify({"status": "error", "message": str(error)}), 500
 
     progress_value = progress.get(sequence_id, 0)
-
     return jsonify({"status": "success", "photos": len(photos), "progress": progress_value}), 200
 
+
+@app.route('/get-user-sequences', methods=['POST'])
+def get_user_sequences():
+    user_name = request.form.get('user_name')
+    to_path = args.to_path
+
+    osc_api_instance = OSCApi(OSCAPISubDomain.PRODUCTION)
+    sequences, error = osc_api_instance.user_sequences(user_name, to_path)
+
+    if error:
+        return jsonify({"status": "error", "message": str(error)}), 500
+    else:
+        return jsonify({'status': 'success', 'message': "Sequences successfully fetched"}), 200
+
+
+@app.route('/get-missing-sequences', methods=['POST'])
+def get_missing_sequences():
+    user_name = request.form.get('user_name')
+    to_path = args.to_path
+
+    osc_api_instance = OSCApi(OSCAPISubDomain.PRODUCTION)
+    sequences, error = osc_api_instance.get_missing_sequences(user_name, to_path)
+    if error:
+        return jsonify({"status": "error", "message": str(error)}), 500
+    else:
+        return jsonify({'status': 'success', 'message': "Sequences successfully fetched"}), 200
+
+
+@app.route('/get-user-name', methods=['POST'])
+def get_user_name():
+    CREDENTIALS_FILE = os.path.join(os.path.expanduser("~"), ".config", "mapilio", "configs", "MapSyncer",
+                                    "credentials.json")
+    if os.path.exists(CREDENTIALS_FILE):
+        with open(CREDENTIALS_FILE, 'r') as f:
+            credentials = json.load(f)
+            user_name = credentials.get("osc", {}).get("user_name")
+            return jsonify({"status": "success", "user_name": user_name})
+    else:
+        return None
+
+
 if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=5050, threaded=True)
+    app.run(host='0.0.0.0', port=5050, threaded=True, debug=True)

--- a/MapSyncer/components/get_exif.py
+++ b/MapSyncer/components/get_exif.py
@@ -67,6 +67,7 @@ def get_api_access_token():
         ".config",
         "mapilio",
         "configs",
+        "MapSyncer",
         "credentials.json"
     )
 
@@ -91,6 +92,15 @@ def get_exif(seq_id, sequence_path, lth_images):
         seq_id (str): The sequence ID.
         sequence_path (str): The path to the sequence folder.
     """
+    DOWNLOAD_LOGS = os.path.join(
+        os.path.expanduser("~"),
+        ".config",
+        "mapilio",
+        "configs",
+        "MapSyncer",
+        "download_logs.json"
+    )
+
     access_token = get_api_access_token()
 
     if access_token is None:
@@ -246,15 +256,13 @@ def get_exif(seq_id, sequence_path, lth_images):
         save_path = os.path.join(sequence_path, 'mapilio_image_description.json')
         with open(save_path, 'w') as outfile:
             json.dump(mapilio_description, outfile)
-        current_directory = os.path.dirname(os.path.abspath(__file__))
-        parent_directory = os.path.dirname(current_directory)
-        download_logs_json_path = os.path.join(parent_directory, ".download_logs.json")
-        with open(download_logs_json_path, 'r') as f:
+
+        with open(DOWNLOAD_LOGS, 'r') as f:
             data = json.load(f)
         for item in data:
             if item.get('seq_id') == seq_id:
                 item['json_success'] = True
-        with open(download_logs_json_path, 'w') as f:
+        with open(DOWNLOAD_LOGS, 'w') as f:
             json.dump(data, f)
 
     except requests.exceptions.RequestException as e:

--- a/MapSyncer/components/login_controller.py
+++ b/MapSyncer/components/login_controller.py
@@ -16,6 +16,7 @@ CREDENTIALS_FILE = os.path.join(
         ".config",
         "mapilio",
         "configs",
+        "MapSyncer",
         "credentials.json"
     )
 OSM_KEY = "osm"

--- a/MapSyncer/run.py
+++ b/MapSyncer/run.py
@@ -12,13 +12,20 @@ from colorama import (Fore,
 import requests
 from .components.version_ import __version__
 
-current_directory = os.path.dirname(os.path.abspath(__file__))
-download_logs_json_path = os.path.join(current_directory, ".download_logs.json")
+DOWNLOAD_LOGS = os.path.join(
+        os.path.expanduser("~"),
+        ".config",
+        "mapilio",
+        "configs",
+        "MapSyncer",
+        "download_logs.json"
+    )
 
 IMAGES_DOWNLOAD_PATH = os.path.join(
         os.path.expanduser("~"),
         ".cache",
         "mapilio",
+        "MapSyncer",
         "images"
     )
 
@@ -46,26 +53,13 @@ def main():
 
     init_colorama()
 
-    check_authenticate = False
+    print(f"{Fore.LIGHTCYAN_EX}To access the web interface of MapSyncer, simply navigate to the following URL:\n"
+          f"http://localhost:5050/ in your web browser's address bar.\n{Fore.RESET}")
 
-    if len(list_all_users()) == 0:
-        check_authenticate = check_auth()
-    elif len(list_all_users()) >= 2:
-        username = input("Found multiple Mapilio accounts. Please specify your username.\n")
-    else:
-        check_authenticate = True
+    if not os.path.exists(IMAGES_DOWNLOAD_PATH):
+        os.makedirs(IMAGES_DOWNLOAD_PATH)
 
-    if check_authenticate:
-
-        print(f"{Fore.LIGHTCYAN_EX}To access the web interface of MapSyncer, simply navigate to the following URL:\n"
-              f"http://localhost:5050/ in your web browser's address bar.\n{Fore.RESET}")
-
-        if not os.path.exists(IMAGES_DOWNLOAD_PATH):
-            os.makedirs(IMAGES_DOWNLOAD_PATH)
-        flask_app(IMAGES_DOWNLOAD_PATH)
-        download_user_images(IMAGES_DOWNLOAD_PATH)
-
-        folder_selection(IMAGES_DOWNLOAD_PATH)
+    flask_app(IMAGES_DOWNLOAD_PATH)
 
 
 def get_args_mapilio(func):
@@ -99,7 +93,6 @@ def check_auth():
             return check_authenticate
         else:
             check_auth()
-
     else:
         print("Please enter your username, email and password properly \n\n\n\n\n")
         check_auth()
@@ -129,7 +122,7 @@ def folder_selection(path):
         print(f"{Fore.LIGHTYELLOW_EX}Uploading all folders...")
         folders_to_upload = []
 
-        with open(download_logs_json_path, 'r') as f:
+        with open(DOWNLOAD_LOGS, 'r') as f:
             data = json.load(f)
             for folder in data:
                 if not folder.get('json_success'):
@@ -159,7 +152,7 @@ def folder_selection(path):
                     print(f"{Fore.RED}Error occurred while uploading {folder_path}")
                     continue
 
-            update_folder_status(folder_name_numeric, download_logs_json_path)
+            update_folder_status(folder_name_numeric, DOWNLOAD_LOGS)
         print(f"{Fore.LIGHTGREEN_EX}All folders uploaded. 🎉")
 
     elif choice == '2':
@@ -171,7 +164,7 @@ def folder_selection(path):
         print(f"{Fore.YELLOW}Uploading folder '{folder_name_numeric}'... {Fore.RESET}")
 
         upload_command = f"mapilio_kit upload --processed {path + '/' + folder_name_numeric}"
-        with open(download_logs_json_path, 'r') as f:
+        with open(DOWNLOAD_LOGS, 'r') as f:
             data = json.load(f)
             for folder in data:
                 if folder.get('seq_id') == folder_name_numeric:
@@ -186,7 +179,7 @@ def folder_selection(path):
         if result != 0:
             print(f"{Fore.RED}Error occurred while uploading {folder_name_numeric}")
         else:
-            update_folder_status(folder_name_numeric, download_logs_json_path)
+            update_folder_status(folder_name_numeric, DOWNLOAD_LOGS)
 
         folder_selection(path)
 


### PR DESCRIPTION
- Flask design was made for Mapilio login system and now login will be done in the interface.
- A stable path has been entered for the download_log File.
- Added pagination system to the page where sequences are shown. There will be 39 sequences on each page.
- Users can no longer retrieve their sequences from the terminal, but through the web interface.
- If there is no gnome-terminal in the Linux operating system, the Flask App will be run in the default bash terminal.