### PR TITLE
The error message received when an OpenStreetMap account is not associated with Kartaview has been changed.

### DIFF
--- a/MapSyncer/app.py
+++ b/MapSyncer/app.py
@@ -3,6 +3,7 @@ import math
 import os
 import shutil
 import ssl
+import webbrowser
 
 from flask import Flask, render_template, request, jsonify, redirect, url_for, session
 from mapilio_kit.base import authenticator
@@ -367,8 +368,8 @@ def remove_accounts():
 def main():
     ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
     ssl_context.load_cert_chain(CERT_PEM, KEY_PEM)
-    app.run(host='0.0.0.0', port=5050, threaded=True, debug=True, ssl_context=ssl_context)
-
+    webbrowser.open('https://127.0.0.1:5050')
+    app.run(host='0.0.0.0', port=5050, threaded=True, debug=False, ssl_context=ssl_context)
 
 if __name__ == '__main__':
     main()

--- a/MapSyncer/components/osc_api_gateway.py
+++ b/MapSyncer/components/osc_api_gateway.py
@@ -345,7 +345,10 @@ class OSCApi:
             return None, ex
 
         if 'totalFilteredItems' not in json_response:
-            return [], Exception("OSC API bug missing totalFilteredItems from response")
+            api_message = json_response.get('status', {}).get('apiMessage', 'Unknown Error')
+            if api_message == "Invalid username!":
+                return [], Exception("No Kartaview account associated with OpenStreetMap was found.")
+            return [], Exception(f"OSC API error: {api_message}")
 
         total_items = int(json_response['totalFilteredItems'][0])
         pages_count = int(total_items / parameters['ipp']) + 1

--- a/MapSyncer/templates/display-sequence.html
+++ b/MapSyncer/templates/display-sequence.html
@@ -19,7 +19,6 @@
             text-overflow: ellipsis;
             white-space: nowrap;
         }
-
     </style>
 </head>
 <body>
@@ -179,9 +178,13 @@
                 </div>
             </div>
             {% endfor %}
-            <div class="alert alert-warning alert-dismissible fade show mt-4" role="alert" id="info-message-missing">
-                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button><p>If you think your sequences are missing, please <a href="#" id="clickHere" class="text-decoration-none">click here</a>.</p></button>
-            </div>
+            {% if not sequence_data %}
+                <div class="col-12 text-center mt-4">
+                    <div class="alert alert-warning" role="alert">
+                        No sequence to fetch was found in your KartaView account.
+                    </div>
+                </div>
+            {% endif %}
         </div>
         {% endif %}
     </div>
@@ -195,7 +198,7 @@
         } else {
             localStorage.setItem('user_name', user_name);
         }
-      </script>
+    </script>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.3/css/bootstrap.min.css" rel="stylesheet">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.3/js/bootstrap.bundle.min.js"></script>
 </body>


### PR DESCRIPTION
- If the user's OpenStreetMap account is not associated with Kartaview, the error message has been changed to be more informative for the user.

- If the sequence cannot be found in the Kartaview account, an informative message has been added on the display-sequence page.