### PR TITLE
Fix args resps

### DIFF
--- a/MapSyncer/app.py
+++ b/MapSyncer/app.py
@@ -8,8 +8,8 @@ import webbrowser
 import requests
 from flask import Flask, render_template, request, jsonify, redirect, url_for, session
 from mapilio_kit.base import authenticator
-from mapilio_kit.components.edit_config import edit_config
-from mapilio_kit.components.login import list_all_users
+from mapilio_kit.components.utilities.edit_config import edit_config
+from mapilio_kit.components.auth.login import list_all_users
 from osm_login_python.core import Auth
 
 from MapSyncer.components.download import download_user_images, check_sequence_status, progress

--- a/MapSyncer/components/get_exif.py
+++ b/MapSyncer/components/get_exif.py
@@ -121,7 +121,7 @@ def get_exif(seq_id, sequence_path, lth_images):
         api_data_details = response_details.json()
 
         while hasMoreData:
-            # There is no need to use acces token.
+            # No need to use access token.
             # url = f"https://api.openstreetcam.org/2.0/photo/?access_token={access_token}&sequenceId={seq_id}&page={page_count}"
             url = f"https://api.openstreetcam.org/2.0/photo/?&sequenceId={seq_id}&page={page_count}"
             response_photos = requests.get(url)
@@ -186,24 +186,19 @@ def get_exif(seq_id, sequence_path, lth_images):
                     platform = api_data_details.get("osv", {}).get("platform")
 
                     if platform == "iOS" or "iPhone" in platform:
-                        device_make = "Apple"
-                        device_model = device_name.split(",")[0].replace("iPhone", "iPhone ")
+                        device_make, device_model = "Apple", device_name.split(",")[0].replace("iPhone", "iPhone ")
 
                     elif platform == "Android" and " " in device_name:
-                        device_make = device_name.split(" ")[0]
-                        device_model = device_name.split(" ", 1)[1]
+                        device_make, device_model = device_name.split(" ")[0], device_name.split(" ", 1)[1]
 
                     elif platform == "samsung":
-                        device_make = "Samsung"
-                        device_model = device_name
+                        device_make, device_model = "Samsung", device_name
 
                     elif platform == "GoPro":
-                        device_make = "GoPro"
-                        device_model = device_name
+                        device_make, device_model = "GoPro", device_name
 
                     else:
-                        device_make = "Unknown"
-                        device_model = "Unknown"
+                        device_make, device_model = "Unknown", "Unknown"
 
                     photo_data = \
                         {
@@ -231,17 +226,19 @@ def get_exif(seq_id, sequence_path, lth_images):
                             "vfov": vfov,
                             "focalLength": fLen,
                             "filename": api_photo_data["name"],
-                            "accuracy_level": float(api_photo_data["gpsAccuracy"]) if api_photo_data.get(
-                                "gpsAccuracy") is not None else None,
                             "path": ""
                         }
 
+                    if api_photo_data.get("gpsAccuracy") is not None: photo_data["accuracy_level"] = float(api_photo_data["gpsAccuracy"])
                     mapilio_description.append(photo_data)
                     processed_count += 1
                 page_count += 1
                 hasMoreData = api_data_photos['result'].get('hasMoreData', False)
             else:
-                print("No 'data' key found in the JSON response.")
+                if "empty" in api_data_photos['status']['apiMessage']:
+                    print(f"{Fore.YELLOW}{api_data_photos['status']['apiMessage']}, so skipping the {page_count} page.{Fore.RESET}")
+                    hasMoreData = False
+
 
         description_information = {
             "Information": {


### PR DESCRIPTION
_**What's done in details?**_
* For a start there was a problem on gpsAccuracy parameter, if it wasn't exist with the coming data, it was being written as null, which we don't accept it.  
* Another problem was on the empty responses, during the page checking process, if the data was not available the project was keep trying the check the same page, however, there are situations like the user does not have enough data (the page does not exist), and the data is not available. This is fixed either. 
